### PR TITLE
Intellij scala plugin is able to infer result type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Import Groupable._:
 import com.agilogy.utils.Groupable._
 ```
 
-Now, a new method `group` is available on TraversableOnce[T]:
+Now, two new methods `group` are available on TraversableOnce[T]:
 
 ```
-def group[GT, RT](by: (T) ⇒ GT, as: (T) ⇒ RT = identity[T]): Seq[(GT, Seq[RT])]
+def group[GT, RT](by: ((T) => GT)): Seq[(GT, Seq[T])]
+def group[GT, RT](by: (T) ⇒ GT, as: (T) ⇒ RT): Seq[(GT, Seq[RT])]
 ```
 
 Example (from the tests):

--- a/src/main/scala/com/agilogy/utils/Groupable.scala
+++ b/src/main/scala/com/agilogy/utils/Groupable.scala
@@ -5,8 +5,10 @@ import scala.collection.mutable.ListBuffer
 object Groupable {
 
   implicit class GroupableTraversable[T](i: TraversableOnce[T]) {
-    
-    def group[GT, RT](by: ((T) => GT), as: ((T) => RT) = identity[T] _): Seq[(GT, Seq[RT])] = {
+
+    def group[GT, RT](by: ((T) => GT)): Seq[(GT, Seq[T])] = group(by,identity[T])
+
+    def group[GT, RT](by: ((T) => GT), as: ((T) => RT)): Seq[(GT, Seq[RT])] = {
       if (i.isEmpty) Seq()
       else {
         val result = new ListBuffer[(GT, Seq[RT])]


### PR DESCRIPTION
Patch to fix Intellij Scala Plugin (version 1.3.3) problem to infer result type
- Before:
  val test: Seq[(Int, Seq[Nothing])] = Seq.empty[Int].group(_*2)
- Now:
  val test: Seq[(Int, Seq[Int])] = Seq.empty[Int].group(_*2)
