### PR TITLE
Update sbt and migrate publishing to GitLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The method is added to TraversableOnce and subclasses via [Pimp my Library Patte
 ## Installation
 
 ```
-resolvers += Resolver.url("Agilogy Scala",url("http://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
 
 libraryDependencies += "com.agilogy" %% "groupable" % "1.1"
 ```
@@ -55,6 +55,14 @@ it should "group mapping values" in {
 ## Roadmap
 
 - Maybe we could use a typeclass so that not only `TraversableOne`s are groupables. As an example, it could be interesting for `ResultSet`s.
+
+## Publishing
+
+To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
+
+```
+sbt:groupable> +publish
+```
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The method is added to TraversableOnce and subclasses via [Pimp my Library Patte
 ## Installation
 
 ```
-resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/-/packages/maven"
 
-libraryDependencies += "com.agilogy" %% "groupable" % "1.1"
+libraryDependencies += "com.agilogy" %% "groupable" % "1.2"
 ```
 
 ## Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import bintray.Keys._
+import com.gilcloud.sbt.gitlab.{GitlabCredentials,GitlabPlugin}
 
 organization := "com.agilogy"
 
@@ -6,22 +6,26 @@ name := "groupable"
 
 version := "1.1"
 
-crossScalaVersions := Seq("2.10.7","2.11.12","2.12.6")
+crossScalaVersions := Seq("2.11.12","2.12.13")
 
 libraryDependencies +=   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 publishMavenStyle := false
 
-// --> bintray
+// --> gitlab
 
-seq(bintrayPublishSettings:_*)
+GitlabPlugin.autoImport.gitlabGroupId := None
+GitlabPlugin.autoImport.gitlabProjectId := Some(26236490)
+GitlabPlugin.autoImport.gitlabDomain := "gitlab.com"
 
-repository in bintray := "scala"
+GitlabPlugin.autoImport.gitlabCredentials := {
+    val token = sys.env.get("GITLAB_DEPLOY_TOKEN") match {
+        case Some(token) => token
+        case None =>
+            sLog.value.warn(s"Environment variable GITLAB_DEPLOY_TOKEN is undefined, 'publish' will fail.")
+            ""
+    }
+    Some(GitlabCredentials("Deploy-Token", token))
+}
 
-bintrayOrganization in bintray := Some("agilogy")
-
-packageLabels in bintray := Seq("scala")
-
-licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-
-// <-- bintray
+// <-- gitlab

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ crossScalaVersions := Seq("2.11.12","2.12.13")
 
 libraryDependencies +=   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
-publishMavenStyle := false
-
 // --> gitlab
 
 GitlabPlugin.autoImport.gitlabGroupId := None

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.agilogy"
 
 name := "groupable"
 
-version := "1.1"
+version := "1.2"
 
 crossScalaVersions := Seq("2.11.12","2.12.13")
 

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,6 +1,0 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases", 
-  url("https://dl.bintray.com/content/sbt/sbt-plugin-releases")
-)(Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
+
+addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.6")


### PR DESCRIPTION
Bintray is shutting down on May 1st, so we are moving to a different platform.
Packages for `groupable` are already published on [Agilogy's Package Registry](https://gitlab.com/groups/agilogy/-/packages) on GitLab.